### PR TITLE
Input 컴포넌트 구성 & design-example 리팩토링

### DIFF
--- a/src/components/basic/Input/index.tsx
+++ b/src/components/basic/Input/index.tsx
@@ -1,0 +1,41 @@
+import { InputHTMLAttributes, useMemo, useState } from 'react';
+
+import { Wrapper, OutlineInput, UnderlineInput, Placeholder } from './style';
+
+interface Props extends InputHTMLAttributes<HTMLInputElement> {
+  underline?: boolean;
+}
+
+function CommonInput({ type = 'text', underline = false, value, placeholder, onChange }: Props) {
+  const [isInputFocused, setIsInputFocused] = useState(false);
+  const hasValue = useMemo(() => !!value, [value]);
+
+  const handleFocus = () => {
+    setIsInputFocused(true);
+  };
+
+  const handleBlur = () => {
+    setIsInputFocused(false);
+  };
+
+  return (
+    <>
+      {underline ? (
+        <UnderlineInput type={type} value={value} onChange={onChange} placeholder={placeholder} />
+      ) : (
+        <Wrapper>
+          <Placeholder isAnimationOn={isInputFocused || hasValue}>{placeholder}</Placeholder>
+          <OutlineInput
+            type={type}
+            value={value}
+            onChange={onChange}
+            onFocus={handleFocus}
+            onBlur={handleBlur}
+          />
+        </Wrapper>
+      )}
+    </>
+  );
+}
+
+export default CommonInput;

--- a/src/components/basic/Input/style.ts
+++ b/src/components/basic/Input/style.ts
@@ -1,0 +1,66 @@
+import styled from '@emotion/styled';
+import { css } from '@emotion/react';
+
+interface PlaceHolderProps {
+  isAnimationOn: boolean;
+}
+
+const defaultInput = css`
+  width: 200px;
+  height: 30px;
+  padding: 8px;
+
+  font-size: 16px;
+  font-weight: normal;
+
+  border: none;
+
+  &:focus {
+    outline: none;
+  }
+`;
+
+const Wrapper = styled.div`
+  position: relative;
+`;
+
+const OutlineInput = styled.input`
+  ${defaultInput}
+
+  border-radius: 4px;
+  border: 1px solid #9d9d9d;
+
+  &:focus {
+    border: 1px solid #023e8a;
+  }
+`;
+
+const UnderlineInput = styled.input`
+  ${defaultInput}
+
+  border-bottom: 1px solid #9D9D9D;
+
+  &:focus {
+    border-bottom: 1px solid #023e8a;
+  }
+`;
+
+const Placeholder = styled.p<PlaceHolderProps>`
+  position: absolute;
+  top: 16px;
+  left: 9px;
+
+  color: #999;
+  background: #fff;
+
+  transition: all 150ms ease-out;
+  ${({ isAnimationOn }) =>
+    isAnimationOn &&
+    `
+    transform:translateY(-23px);
+    font-size:14px;
+    padding: 0 4px;
+  `}}
+`;
+
+export { Wrapper, OutlineInput, UnderlineInput, Placeholder };

--- a/src/components/basic/Input/style.ts
+++ b/src/components/basic/Input/style.ts
@@ -57,9 +57,10 @@ const Placeholder = styled.p<PlaceHolderProps>`
   ${({ isAnimationOn }) =>
     isAnimationOn &&
     `
-    transform:translateY(-23px);
+    transform: translateY(-22px);
     font-size:14px;
     padding: 0 4px;
+    color: #023e8a;
   `}}
 `;
 

--- a/src/designExamples/Button.tsx
+++ b/src/designExamples/Button.tsx
@@ -1,0 +1,32 @@
+import Row from '@src/components/basic/grid/Row';
+import { Button } from '@src/components/basic/Button/style';
+
+import { ColorType, SizeType } from '@src/types';
+
+import { Padding, Title } from './style';
+
+function ButtonExample() {
+  const colorList: ColorType[] = ['primary', 'secondary', 'tertiary'];
+  const sizeList: SizeType[] = ['small', 'medium', 'big'];
+  return (
+    <>
+      <Padding>
+        <Title bold>Buttons</Title>
+      </Padding>
+      {colorList.map((color, index) => (
+        <Row key={color + index.toString()} alignItems="center">
+          <Title>{color}</Title>
+          {sizeList.map((size) => (
+            <Padding key={size + index.toString()}>
+              <Button color={color} size={size} onClick={() => {}}>
+                {size}
+              </Button>
+            </Padding>
+          ))}
+        </Row>
+      ))}
+    </>
+  );
+}
+
+export default ButtonExample;

--- a/src/designExamples/Dropdown.tsx
+++ b/src/designExamples/Dropdown.tsx
@@ -1,0 +1,21 @@
+import Dropdown from '@src/components/basic/Dropdown';
+import Row from '@src/components/basic/grid/Row';
+
+import { Title, Padding } from './style';
+
+function DropdownExample() {
+  return (
+    <>
+      <Padding>
+        <Title bold>Dropdown</Title>
+      </Padding>
+      <Row>
+        <Padding>
+          <Dropdown items={['item1', 'item2', 'item3', 'item4']} onChange={(v) => console.log(v)} />
+        </Padding>
+      </Row>
+    </>
+  );
+}
+
+export default DropdownExample;

--- a/src/designExamples/Input.tsx
+++ b/src/designExamples/Input.tsx
@@ -1,0 +1,43 @@
+import Input from '@src/components/basic/Input';
+import Row from '@src/components/basic/grid/Row';
+
+import useInput from '@src/hooks/useInput';
+
+import { Title, Padding } from './style';
+
+function InputExample() {
+  const { state: defaultState, handleChange: handleChangeDefault } = useInput('');
+  const { state: UnderlineState, handleChange: handleChangeUnderline } = useInput('');
+
+  return (
+    <>
+      <Padding>
+        <Title bold>Input</Title>
+      </Padding>
+      <Row alignItems="center">
+        <Title>Default</Title>
+        <Padding>
+          <Input
+            type="email"
+            value={defaultState}
+            onChange={handleChangeDefault}
+            placeholder="e-mail"
+          />
+        </Padding>
+      </Row>
+      <Row alignItems="center">
+        <Title>Underline</Title>
+        <Padding>
+          <Input
+            underline
+            value={UnderlineState}
+            onChange={handleChangeUnderline}
+            placeholder="검색어를 입력하세요"
+          />
+        </Padding>
+      </Row>
+    </>
+  );
+}
+
+export default InputExample;

--- a/src/designExamples/style.ts
+++ b/src/designExamples/style.ts
@@ -1,0 +1,12 @@
+import styled from '@emotion/styled';
+
+const Padding = styled.div`
+  padding: 20px;
+`;
+
+const Title = styled.div<{ bold?: boolean }>`
+  width: 100px;
+  font-weight: ${(props) => (props.bold ? '700' : '500')};
+`;
+
+export { Padding, Title };

--- a/src/hooks/useInput.ts
+++ b/src/hooks/useInput.ts
@@ -1,0 +1,13 @@
+import { ChangeEvent, useState } from 'react';
+
+function useInput(initialState: string) {
+  const [state, setState] = useState(initialState);
+
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+    setState(e.target.value);
+  };
+
+  return { state, handleChange };
+}
+
+export default useInput;

--- a/src/pages/DesignExample/index.tsx
+++ b/src/pages/DesignExample/index.tsx
@@ -1,42 +1,18 @@
-import Button from '@src/components/basic/Button';
 import Column from '@src/components/basic/grid/Column';
-import Row from '@src/components/basic/grid/Row';
-import Dropdown from '@src/components/basic/Dropdown';
 
-import { ColorType, SizeType } from '@src/types';
+import ButtonExample from '@src/designExamples/Button';
+import DropdownExample from '@src/designExamples/Dropdown';
+import InputExample from '@src/designExamples/Input';
 
-import { Wrapper, Padding, Title } from './style';
+import { Wrapper } from './style';
 
 function DesignExamplePage() {
-  const colorList: ColorType[] = ['primary', 'secondary', 'tertiary'];
-  const sizeList: SizeType[] = ['small', 'medium', 'big'];
   return (
     <Wrapper>
-      <Title bold>Buttons</Title>
       <Column>
-        {colorList.map((color, index) => (
-          <Row key={color + index.toString()} alignItems="center">
-            <Title>{color}</Title>
-            {sizeList.map((size) => (
-              <Padding key={size + index.toString()}>
-                <Button color={color} size={size} onClick={() => {}}>
-                  {size}
-                </Button>
-              </Padding>
-            ))}
-          </Row>
-        ))}
-      </Column>
-      <Column>
-        <Title bold>Dropdown</Title>
-        <Row>
-          <Padding>
-            <Dropdown
-              items={['item1', 'item2', 'item3', 'item4']}
-              onChange={(v) => console.log(v)}
-            />
-          </Padding>
-        </Row>
+        <ButtonExample />
+        <DropdownExample />
+        <InputExample />
       </Column>
     </Wrapper>
   );

--- a/src/pages/DesignExample/style.ts
+++ b/src/pages/DesignExample/style.ts
@@ -4,13 +4,4 @@ const Wrapper = styled.div`
   padding: 20px;
 `;
 
-const Padding = styled.div`
-  padding: 20px;
-`;
-
-const Title = styled.div<{ bold?: boolean }>`
-  width: 100px;
-  font-weight: ${(props) => (props.bold ? '700' : '500')};
-`;
-
-export { Wrapper, Padding, Title };
+export { Wrapper };


### PR DESCRIPTION
### ➕ 추가한 기능
- Input 컴포넌트 구현
- design-example 리팩토링
<br/>

### ❓ PR 리뷰 시 중점적으로 리뷰하고 싶은 부분
- useInput 훅 관련
- Input 컴포넌트는 default(테두리가 있는 input), underline(아래줄만 있는 input) 2종류로 구성했습니다. 와이어프레임에 필요한 input은 두 종류인 것 굳이 두 개로 나눴는데 필요없다면 한 가지 input만 만들어도 될 것 같습니다.
- default input과 같은 경우 placeholder 관련 animation을 살짝 구현해 봤습니다.
- design-example 페이지 관련 리팩토링 진행 (확인 후 고치고 싶은 부분이 없다면 이대로 진행, 고치고 싶은 부분이 있다면 코멘트 부탁드립니다.)

구현 결과 입니다.

https://user-images.githubusercontent.com/60134628/218241865-78578e75-7a72-4d42-9b91-ccee67777c87.mov
